### PR TITLE
Change Icon to Widget

### DIFF
--- a/lib/src/badge_icon_button.dart
+++ b/lib/src/badge_icon_button.dart
@@ -9,7 +9,7 @@ class BadgeIconButton extends StatefulWidget {
   final VoidCallback onPressed;
   final int itemCount;
   final Color badgeColor;
-  final Icon icon;
+  final Widget icon;
   final bool hideZeroCount;
   final bool toAnimate;
   final BadgePosition position;


### PR DESCRIPTION
Changing the Icon to a Widget makes your plugin much more useful.